### PR TITLE
BrowserHttpServerHttpResponse fixed number jsonizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The message posted back is a response in JSON form.
   "status-code": 400,
   "status-message": "Bad request 123",
   "headers": {
-    "Content-Length": "1",
+    "Content-Length": 9,
     "Content-Type": "text/plain123"
   },
   "body": "Body123"

--- a/src/main/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpResponse.java
+++ b/src/main/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpResponse.java
@@ -109,8 +109,12 @@ final class BrowserHttpServerHttpResponse implements HttpResponse {
                 case 0:
                     break;
                 case 1:
-                    final String headerValueText = header.headerText(Cast.to(values.get(0)));
-                    headers.add(JsonNode.string(headerValueText).setName(JsonPropertyName.with(header.value())));
+                    final Object value = values.get(0);
+                    final JsonNode valueJsonNode = value instanceof Number ?
+                            JsonNode.number(((Number) value).doubleValue()) :
+                            JsonNode.string(header.headerText(Cast.to(value)));
+
+                    headers.add(valueJsonNode.setName(JsonPropertyName.with(header.value())));
                     break;
                 default:
                     throw new IllegalArgumentException("Header " + header + " contains " + valueCount + " values only 1 supported=" + values);

--- a/src/test/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpResponseTest.java
@@ -152,7 +152,7 @@ public final class BrowserHttpServerHttpResponseTest extends BrowserHttpServerTe
 
         this.check(response, "{\n" +
                 "  \"headers\": {\n" +
-                "    \"Content-Length\": \"1\"\n" +
+                "    \"Content-Length\": 1\n" +
                 "  }\n" +
                 "}");
     }
@@ -167,7 +167,7 @@ public final class BrowserHttpServerHttpResponseTest extends BrowserHttpServerTe
         this.check(response, "{\n" +
                 "  \"headers\": {\n" +
                 "    \"Content-Type\": \"text/plain\",\n" +
-                "    \"Content-Length\": \"1\"\n" +
+                "    \"Content-Length\": 1\n" +
                 "  }\n" +
                 "}");
     }
@@ -181,7 +181,7 @@ public final class BrowserHttpServerHttpResponseTest extends BrowserHttpServerTe
 
         this.check(response, "{\n" +
                 "  \"headers\": {\n" +
-                "    \"Content-Length\": \"1\",\n" +
+                "    \"Content-Length\": 1,\n" +
                 "    \"Content-Type\": \"text/plain\"\n" +
                 "  }\n" +
                 "}");
@@ -208,7 +208,7 @@ public final class BrowserHttpServerHttpResponseTest extends BrowserHttpServerTe
                 "  \"status-code\": 400,\n" +
                 "  \"status-message\": \"Bad request 123\",\n" +
                 "  \"headers\": {\n" +
-                "    \"Content-Length\": \"1\",\n" +
+                "    \"Content-Length\": 1,\n" +
                 "    \"Content-Type\": \"text/plain123\"\n" +
                 "  },\n" +
                 "  \"body\": \"Body123\"\n" +


### PR DESCRIPTION
- Previously number values were encoded as a json string, this is now fixed they are now number literals.