### PR TITLE
BrowserHttpServerHttpRequest.headers missing

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpRequest.java
@@ -94,7 +94,9 @@ final class BrowserHttpServerHttpRequest implements HttpRequest {
     @Override
     public Map<HttpHeaderName<?>, List<?>> headers() {
         if (null == this.headers) {
-            this.headers = BrowserHttpServerHttpRequestHeadersMap.with(this.json.getOrFail(HEADERS).objectOrFail());
+            this.headers = BrowserHttpServerHttpRequestHeadersMap.with(this.json.get(HEADERS)
+                    .orElse(JsonNode.object())
+                    .objectOrFail());
         }
         return this.headers;
     }

--- a/src/test/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpRequestTest.java
+++ b/src/test/java/walkingkooka/net/http/server/browser/BrowserHttpServerHttpRequestTest.java
@@ -96,6 +96,14 @@ public final class BrowserHttpServerHttpRequestTest extends BrowserHttpServerTes
     }
 
     @Test
+    public void testHeadersMissing() {
+        final BrowserHttpServerHttpRequest request = this.parse("{}");
+        assertEquals(Lists.empty(),
+                request.headers().get(HttpHeaderName.CONTENT_TYPE),
+                () -> request.toString());
+    }
+
+    @Test
     public void testHeaderAbsent() {
         final BrowserHttpServerHttpRequest request = this.parse("{ \"headers\": {\"Content-Length\": 123}}");
         assertEquals(Lists.empty(),


### PR DESCRIPTION
- No longer throws exception defaults to empty headers
- Closes #10