### PR TITLE
junit dependency-management removed

### DIFF
--- a/src/it/junit-test/pom.xml
+++ b/src/it/junit-test/pom.xml
@@ -37,16 +37,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.10</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <testResources>
             <testResource>


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka-net-http-server-browser/network/alert/src/it/junit-test/pom.xml/junit:junit/open
- Bump junit from 4.10 to 4.13.1 in /src/it/junit-test  dependencies